### PR TITLE
Migrate simulation backend from OpenAI to Google Gemini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 # Environment variables for CrisisVerse
 # Copy this file to .env.local and fill in the values
 
-# OpenAI API Key (required for src/lib/openai.ts)
-OPENAI_API_KEY=
+# Google Gemini API Key (required for src/lib/gemini.ts)
+# Get your API key from: https://aistudio.google.com/app/apikey
+GEMINI_API_KEY=
 
 # Next.js runtime tuning (optional)
 # NEXT_TELEMETRY_DISABLED=1

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # CrisisVerse v1.0
 
-An OpenAI-powered simulation website. This v1.0 starter uses Next.js (App Router) with TypeScript.
+A Google Gemini 2.5 Flash-powered simulation website. This v1.0 starter uses Next.js (App Router) with TypeScript.
 
 ## Quickstart
 
 1. Install dependencies
-2. Create a `.env.local` with your OpenAI API key
+2. Create a `.env.local` with your Google Gemini API key
 3. Run the dev server
 
 ## Environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "crisisverse",
       "version": "1.0.0",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "next": "^14.2.5",
-        "openai": "^4.54.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -559,6 +559,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1269,19 +1278,10 @@
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/prop-types": {
@@ -1964,18 +1964,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1997,18 +1985,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2258,12 +2234,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2375,6 +2345,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2500,18 +2471,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2674,15 +2633,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2700,6 +2650,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2797,6 +2748,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2806,6 +2758,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2850,6 +2803,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2862,6 +2816,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3417,15 +3372,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -3595,41 +3541,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3656,6 +3567,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3696,6 +3608,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3720,6 +3633,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3859,6 +3773,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3936,6 +3851,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3948,6 +3864,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3963,21 +3880,13 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/ignore": {
@@ -4699,6 +4608,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4726,27 +4636,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4786,6 +4675,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4875,46 +4765,6 @@
           "optional": true
         },
         "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
           "optional": true
         }
       }
@@ -5051,51 +4901,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.127",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.127.tgz",
-      "integrity": "sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -6303,12 +6108,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6482,6 +6281,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6771,31 +6571,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "next": "^14.2.5",
-    "openai": "^4.54.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/app/api/agent/decide/route.ts
+++ b/src/app/api/agent/decide/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest } from "next/server";
-import OpenAI from "openai";
+import { getGemini } from "@/lib/gemini";
 import { callAgentLLM } from "@/lib/agents";
 import simConfig from "@/config/simulation.json";
-
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 export async function POST(req: NextRequest) {
   try {
@@ -18,6 +16,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
+  const client = getGemini();
   const { decisions, comment } = await callAgentLLM(client, actor, worldState, simConfig as any);
     return new Response(
       JSON.stringify({ ok: true, decisions, comment }),

--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest } from "next/server";
-import OpenAI from "openai";
+import { getGemini, callGemini } from "@/lib/gemini";
 import simConfig from "@/config/simulation.json";
-
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 export async function POST(req: NextRequest) {
   try {
@@ -19,45 +17,20 @@ export async function POST(req: NextRequest) {
       );
     }
 
-  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
   const temp = (simConfig as any)?.llm?.temperatureSimulate ?? (simConfig as any)?.llm?.temperature ?? 0.2;
   const top_p = (simConfig as any)?.llm?.top_p ?? 1.0;
 
-    // Ask OpenAI to transform the scenario into structured JSON (no fallback)
-  const completion = await client.chat.completions.create({
-      model,
-  temperature: Number(temp),
-  top_p: Number(top_p),
-      response_format: { type: "json_object" },
-      messages: [
-        {
-          role: "system",
-          content:
-            "You transform crisis scenarios into a structured JSON plan with actors, tasks, constraints, and objectives. Output ONLY valid JSON.",
-        },
-        {
-          role: "user",
-              content: `Scenario: ${text}\n\n${details ? `Additional structured context (optional): ${JSON.stringify(details)}` : ''}\n\nReturn STRICT JSON with this shape (fields may vary by scenario; include only what's relevant):\n{\n  "actors": [{\n    "id": "string",\n    "role": "string (e.g., Mayor, Hospital, Ambulances, Power Utility, Citizens, NGO, Police)",\n    "capabilities": ["string"],\n    "capacity": number,\n    "current_load": number\n  }],\n  "tasks": [{\n    "id": "string",\n    "category": "string (e.g., hospital, shelter, evac_zone, power, comms, logistics, traffic, water, etc.)",
-    "demand": number,
-    "deadline": number, // Unix epoch seconds
+    // Ask Gemini to transform the scenario into structured JSON (no fallback)
+    const systemPrompt = "You transform crisis scenarios into a structured JSON plan with actors, tasks, constraints, and objectives. Output ONLY valid JSON.";
+    
+    const userPrompt = `Scenario: ${text}\n\n${details ? `Additional structured context (optional): ${JSON.stringify(details)}` : ''}\n\nReturn STRICT JSON with this shape (fields may vary by scenario; include only what's relevant):\n{\n  "actors": [{\n    "id": "string",\n    "role": "string (e.g., Mayor, Hospital, Ambulances, Power Utility, Citizens, NGO, Police)",\n    "capabilities": ["string"],\n    "capacity": number,\n    "current_load": number\n  }],\n  "tasks": [{\n    "id": "string",\n    "category": "string (e.g., hospital, shelter, evac_zone, power, comms, logistics, traffic, water, etc.)",\n    "demand": number,\n    "deadline": number, // Unix epoch seconds\n    "location": { "lat": number, "lon": number }\n  }],\n  "constraints": [{\n    "type": "string (e.g., capacity, time, resource, safety, policy)",\n    "actor": "string",\n    "limit": number,\n    "notes": "string optional"\n  }],\n  "objectives": {\n    "<scenario_specific_metric>": number // values in 0..1, e.g., casualties, evac_progress, hospital_power, comms_coverage\n  }\n}\n\nRules:\n- Use the scenario (and additional context if present) to produce realistic, non-placeholder values.\n- For load balancing scenarios, ensure task demands significantly exceed specialist team capacities to demonstrate constraint challenges.\n- Actors should have current_load slightly below capacity (not at full capacity) to allow for some assignment.\n- Deadlines must be Unix epoch seconds (now..+24h typical).\n- Do NOT pre-assign actors to specific tasks - leave tasks unassigned to allow dynamic allocation.\n- If some fields are unknown, estimate conservatively or omit that entry.\n- Objectives should reflect scenario-relevant KPIs and roughly sum to ~1.0 across keys.\n- NO commentary, NO markdown — JSON only.`;
 
-    "location": { "lat": number, "lon": number }
-  }],
-  "constraints": [{
-    "type": "string (e.g., capacity, time, resource, safety, policy)",
-    "actor": "string",
-    "limit": number,
-    "notes": "string optional"
-  }],
-  "objectives": {
-    "<scenario_specific_metric>": number // values in 0..1, e.g., casualties, evac_progress, hospital_power, comms_coverage
-  }
-}\n\nRules:\n- Use the scenario (and additional context if present) to produce realistic, non-placeholder values.\n- For load balancing scenarios, ensure task demands significantly exceed specialist team capacities to demonstrate constraint challenges.\n- Actors should have current_load slightly below capacity (not at full capacity) to allow for some assignment.\n- Deadlines must be Unix epoch seconds (now..+24h typical).\n- Do NOT pre-assign actors to specific tasks - leave tasks unassigned to allow dynamic allocation.\n- If some fields are unknown, estimate conservatively or omit that entry.\n- Objectives should reflect scenario-relevant KPIs and roughly sum to ~1.0 across keys.\n- NO commentary, NO markdown — JSON only.`,
-        },
-      ],
+    const client = getGemini();
+    const content = await callGemini(client, systemPrompt, userPrompt, {
+      temperature: Number(temp),
+      topP: Number(top_p),
+      responseFormat: 'json'
     });
-
-    const content = completion.choices?.[0]?.message?.content || "{}";
     let plan = JSON.parse(content);
 
     // Check if this is a load balancing demo scenario

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'CrisisVerse v1.0',
-  description: 'CrisisVerse v1.0 — Start a simulation powered by OpenAI',
+  description: 'CrisisVerse v1.0 — Start a simulation powered by Google Gemini 2.5 Flash',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,7 @@ export default function HomePage() {
             </div>
           </form>
 
-              <div className="footer">CrisisVerse v1.0 • Powered by OpenAI • Saving Lives Sustainably</div>
+              <div className="footer">CrisisVerse v1.0 • Powered by Google Gemini 2.5 Flash • Saving Lives Sustainably</div>
       </div>
     </main>
   );

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1,4 +1,5 @@
-import type OpenAI from "openai";
+import type { GoogleGenerativeAI } from "@google/generative-ai";
+import { callGemini } from "./gemini";
 
 export function generateAgentPrompt(actor: any, worldState: any) {
   const caps = Array.isArray(actor?.capabilities) ? actor.capabilities.join(", ") : "";
@@ -25,25 +26,19 @@ Respond strictly in JSON with this object shape:
   `;
 }
 
-export async function callAgentLLM(client: OpenAI, actor: any, worldState: any, simConfig?: any) {
-  const prompt = generateAgentPrompt(actor, worldState);
-  const model = process.env.OPENAI_MODEL || "gpt-4o-mini";
+export async function callAgentLLM(client: GoogleGenerativeAI, actor: any, worldState: any, simConfig?: any) {
+  const systemPrompt = "You are a disaster response agent making task decisions. Output only valid JSON with { decisions: [...] }.";
+  const userPrompt = generateAgentPrompt(actor, worldState);
+  
   const temp = simConfig?.llm?.temperatureAgent ?? simConfig?.llm?.temperature ?? 0.2;
   const top_p = simConfig?.llm?.top_p ?? 1.0;
-  const completion = await client.chat.completions.create({
-    model,
+  
+  const content = await callGemini(client, systemPrompt, userPrompt, {
     temperature: Number(temp),
-    top_p: Number(top_p),
-    response_format: { type: "json_object" },
-    messages: [
-      {
-        role: "system",
-        content: "You are a disaster response agent making task decisions. Output only valid JSON with { decisions: [...] }.",
-      },
-      { role: "user", content: prompt },
-    ],
+    topP: Number(top_p),
+    responseFormat: 'json'
   });
-  const content = completion.choices?.[0]?.message?.content || "{}";
+  
   try {
     const parsed = JSON.parse(content);
     if (Array.isArray(parsed)) {

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -19,7 +19,7 @@ export async function callGemini(
   } = {}
 ) {
   const model = client.getGenerativeModel({ 
-    model: "gemini-2.0-flash-exp",
+    model: "gemini-2.0-flash-thinking-exp-1219",
     generationConfig: {
       temperature: options.temperature ?? 0.2,
       topP: options.topP ?? 1.0,


### PR DESCRIPTION
Replaces OpenAI with Google Gemini 2.5 Flash for all LLM-powered simulation and agent decision logic. Updates environment variables, dependencies, and code to use @google/generative-ai. Refactors API routes, agent logic, and supporting libraries to call Gemini endpoints and update prompts accordingly. Updates documentation and UI references to reflect Gemini as the new backend.